### PR TITLE
Add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches: [master, develop]
+  pull_request:
+    branches: [master]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [20, 22]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test


### PR DESCRIPTION
## Summary
- Add CI workflow running tests on Node.js 20 and 22
- Triggers on push to master/develop and PRs to master
- Uses `npm ci` for deterministic installs

## Test plan
- [x] Verify CI runs on this PR
- [x] Confirm tests pass on both Node 20 and 22

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a GitHub Actions workflow only, with no runtime or library code changes; main risk is CI failures due to environment/test differences across Node 20/22.
> 
> **Overview**
> Adds a GitHub Actions CI workflow that runs `npm ci` and `npm test` on Ubuntu for pushes to `master`/`develop` and PRs targeting `master`.
> 
> Tests are executed against a Node.js matrix (`20`, `22`) using `actions/setup-node@v4` to ensure compatibility across supported Node versions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dfa77e18b1f9724eb09e61c10aa2d26709fb9b44. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->